### PR TITLE
docs: clarify Python>=3.10 and pip baseline in setup guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,15 @@ or OpenAPI spec where available.
 
 ## Getting Started
 
+### Prerequisites
+
+- Python 3.10+
+- pip 22+
+
 ```bash
+# Verify Python version
+python --version
+
 # Clone the repo
 git clone https://github.com/agent-intent/verifiable-intent.git
 cd verifiable-intent

--- a/README.md
+++ b/README.md
@@ -132,7 +132,15 @@ and delegates the decision; the user may not be present at transaction time.
 
 ## Quick Start
 
+### Prerequisites
+
+- Python 3.10+
+- pip 22+
+
 ```bash
+# Verify Python version
+python --version
+
 # Install (using uv)
 uv venv .venv && source .venv/bin/activate
 uv pip install -e ".[dev]"


### PR DESCRIPTION
## Summary
Adds explicit installation prerequisites so contributors know version requirements before attempting setup.

### Changes
- README: adds **Prerequisites** under Quick Start
  - Python 3.10+
  - pip 22+
  - `python --version` check
- CONTRIBUTING: adds matching **Prerequisites** section under Getting Started

## Why
Issue #1 reported setup friction when users hit version-related errors without seeing prerequisites first.

Closes #1
