### PR TITLE
docs: improve install guidance for older pip/editable installs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,14 @@ or OpenAPI spec where available.
 git clone https://github.com/agent-intent/verifiable-intent.git
 cd verifiable-intent
 
+# Recommended: upgrade pip for pyproject/hatchling editable installs
+python -m pip install --upgrade pip
+
 # Install with dev dependencies (includes pytest)
 pip install -e ".[dev]"
+
+# Fallback if editable install is not supported in your environment:
+# pip install ".[dev]"
 
 # Run the test suite
 pytest

--- a/README.md
+++ b/README.md
@@ -139,7 +139,15 @@ uv pip install -e ".[dev]"
 
 # Or using pip
 python -m venv .venv && source .venv/bin/activate
+
+# Recommended: upgrade pip for pyproject/hatchling editable installs
+python -m pip install --upgrade pip
+
+# Editable install (developer workflow)
 pip install -e ".[dev]"
+
+# Fallback if editable install is not supported in your environment:
+# pip install ".[dev]"
 
 # Run an example
 python examples/autonomous_flow.py


### PR DESCRIPTION
## Summary
Improves setup docs to reduce failures on environments with older pip/editable-install support.

### Changes
- README
  - Adds explicit `python -m pip install --upgrade pip` step before editable install
  - Adds non-editable fallback note: `pip install ".[dev]"`
- CONTRIBUTING
  - Adds same pip upgrade step and fallback note

## Why
Issue #2 highlighted common failures in pyproject/hatchling repos when editable install is attempted with older pip tooling.

Closes #2
