### PR TITLE
ci: add strict MkDocs build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,19 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install docs dependencies
+        run: pip install -e ".[docs]"
+
+      - name: Build docs
+        run: mkdocs build --strict


### PR DESCRIPTION
## Summary
Adds a docs build gate to CI to align quality checks with the changelog claim and catch docs regressions early.

### Changes
- Adds `docs` job to `.github/workflows/ci.yml`
  - Python 3.13 setup
  - install docs deps (`pip install -e ".[docs]"`)
  - run `mkdocs build --strict`

## Why
Issue #3 noted that changelog mentions docs build quality gates, but current CI only runs lint+tests.

Closes #3
